### PR TITLE
Fix ArithmeticOverflow exception when percent is 0

### DIFF
--- a/src/each_progress/progress.cr
+++ b/src/each_progress/progress.cr
@@ -26,6 +26,7 @@ module EachProgress
 
     def remaining_time : Time::Span
       prcnt = percent
+      return Time::Span::ZERO if prcnt == 0
       remaining_prcnt = 100 - prcnt
       prcnts_per_second = @timer.elapsed_time.total_seconds.to_f / prcnt
       (remaining_prcnt * prcnts_per_second).ceil.seconds


### PR DESCRIPTION
When `Progress#percent` is zero, that results in `prcnts_per_second` being infinity (due to dividing by zero). When that `Infinity` value is converted to the Integer-based `Time::Span` it raises an ArithmeticOverflow exception.